### PR TITLE
Management roles

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,3 +1,67 @@
+data "aws_iam_policy_document" "manage_cloudtrails_assume_role" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${var.log_managers}"]
+    }
+
+    condition = {
+      test = "Bool"
+      variable = "aws:MultiFactorAuthPresent"
+      values = ["true"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "manage_cloudtrails_policy_document" {
+  statement {
+    sid = "UpdateCloudTrailBucketPolicy"
+
+    actions = [
+      "s3:PutBucketPolicy",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.cloudtrail_bucket.arn}",
+    ]
+  }
+  # For some reason the ListTagsLogGroup action isn't allowed on the AWS managed
+  # read-only policy, so we explicitly allow it here.
+  statement {
+    sid = "ListLogGroupTags"
+
+    actions = [
+      "logs:ListTagsLogGroup",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_role" "manage_cloudtrails_role" {
+  name = "manage_cloudtrails_role"
+
+  assume_role_policy = "${data.aws_iam_policy_document.manage_cloudtrails_assume_role.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "readonly_cloudtrails_manager" {
+  role       = "${aws_iam_role.manage_cloudtrails_role.id}"
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy" "manage_cloudtrails_policy" {
+  name = "manage_cloudtrails_policy"
+  role = "${aws_iam_role.manage_cloudtrails_role.id}"
+
+  policy = "${data.aws_iam_policy_document.manage_cloudtrails_policy_document.json}"
+}
+
 data "aws_iam_policy_document" "view_cloudtrails_assume_role" {
   statement {
     actions = [

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -9,3 +9,7 @@ variable "cloudtrail_s3_bucket_name" {
 variable "account_id_list" {
   type = "list"
 }
+
+variable "log_viewers" {
+  type = "list"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,3 +13,7 @@ variable "account_id_list" {
 variable "log_viewers" {
   type = "list"
 }
+
+variable "log_managers" {
+  type = "list"
+}


### PR DESCRIPTION
For managing this account we've identified a couple of roles which would be useful:

1. Log viewer: for allowing temporary access to read logs from the S3 bucket, this is useful for if teams need access to an archive of their CloudTrails
2. Log manager: for managing the S3 bucket policy document. As new accounts are created and old ones are retired this role can be used to update the policy adding account IDs as necessary.